### PR TITLE
Update GitHub Actions CI

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Install rust
         id: rust-install
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Install rust
         id: rust-install

--- a/.github/workflows/qc_ruby.yml
+++ b/.github/workflows/qc_ruby.yml
@@ -28,7 +28,7 @@ jobs:
       BUNDLE_GEMFILE: ${{ github.workspace }}/ruby/Gemfile
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install rust
         id: rust-install
@@ -42,7 +42,7 @@ jobs:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ~/.cargo
@@ -68,7 +68,7 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install rust
         id: rust-install
@@ -77,7 +77,7 @@ jobs:
           toolchain: ${{ matrix.rust-toolchain }}
           components: rustfmt, clippy
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ~/.cargo

--- a/.github/workflows/qc_rust.yml
+++ b/.github/workflows/qc_rust.yml
@@ -25,7 +25,7 @@ jobs:
       RUST_ICU_MAJOR_VERSION_NUMBER: 70
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install rust
         id: rust-install
@@ -33,7 +33,7 @@ jobs:
         with:
           toolchain: ${{ matrix.rust-toolchain }}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ~/.cargo
@@ -59,7 +59,7 @@ jobs:
       RUST_ICU_MAJOR_VERSION_NUMBER: 72
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install rust
         id: rust-install
@@ -67,7 +67,7 @@ jobs:
         with:
           components: rustfmt, clippy
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ~/.cargo

--- a/.github/workflows/release_ruby.yml
+++ b/.github/workflows/release_ruby.yml
@@ -28,7 +28,7 @@ jobs:
           - arm64-darwin
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release_rust.yml
+++ b/.github/workflows/release_rust.yml
@@ -13,13 +13,13 @@ jobs:
       RUST_ICU_MAJOR_VERSION_NUMBER: 70
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install rust
         id: rust-install
         uses: dtolnay/rust-toolchain@stable
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ~/.cargo


### PR DESCRIPTION
The following updates are performed:
* update [`actions/cache`](https://github.com/actions/cache) to v3
* update [`actions/checkout`](https://github.com/actions/checkout) to v3

Still using the outdated actions will generate several warnings in CI runs, for example in https://github.com/enquo/enquo-core/actions/runs/4890649875:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/cache@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

The PR will get rid of those warnings.